### PR TITLE
Fix allowing arithmetic expressions without spaces and no need for extra operator e.g. "4+-5". "4-5" works.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <groupId>nl.arothuis</groupId>
@@ -147,6 +148,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>10</source>
                     <target>10</target>

--- a/src/main/antlr4/nl/arothuis/antlr4calculator/core/parser/Calculator.g4
+++ b/src/main/antlr4/nl/arothuis/antlr4calculator/core/parser/Calculator.g4
@@ -8,7 +8,7 @@ MUL: '*';
 DIV: '/';
 ADD: '+';
 SUB: '-';
-NUMBER: '-'?[0-9]+;
+NUMBER: [0-9]+;
 WHITESPACE: [ \r\n\t]+ -> skip;
 
 /*
@@ -40,6 +40,7 @@ start : expression;
  */
 expression
    : NUMBER                                               # Number
+   | '-' right=expression                                 # Negation
    | '(' inner=expression ')'                             # Parentheses
    | left=expression operator=POW right=expression        # Power
    | left=expression operator=(MUL|DIV) right=expression  # MultiplicationOrDivision

--- a/src/main/java/nl/arothuis/antlr4calculator/core/parser/CalculationListener.java
+++ b/src/main/java/nl/arothuis/antlr4calculator/core/parser/CalculationListener.java
@@ -23,6 +23,12 @@ public class CalculationListener extends CalculatorBaseListener {
     }
 
     @Override
+    public void exitNegation(CalculatorParser.NegationContext ctx) {
+        Double right = this.stack.pop();
+        this.stack.push(-1 * right);
+    }
+
+    @Override
     public void exitPower(CalculatorParser.PowerContext ctx) {
         Double right = this.stack.pop();
         Double left = this.stack.pop();

--- a/src/main/java/nl/arothuis/antlr4calculator/core/parser/CalculationVisitor.java
+++ b/src/main/java/nl/arothuis/antlr4calculator/core/parser/CalculationVisitor.java
@@ -13,6 +13,11 @@ public class CalculationVisitor extends CalculatorBaseVisitor<Double> {
         return Double.parseDouble(ctx.NUMBER().getText());
     }
 
+    @Override
+    public Double visitNegation(CalculatorParser.NegationContext ctx) {
+        return -1 * this.visit(ctx.right);
+    }
+
     /**
      * Parentheses are used to give precedence to
      * the expression around which they are wrapped.

--- a/src/test/java/nl/arothuis/antlr4calculator/core/calculator/MathExamples.java
+++ b/src/test/java/nl/arothuis/antlr4calculator/core/calculator/MathExamples.java
@@ -20,7 +20,28 @@ public class MathExamples {
                 Arguments.of("2 ^ 3", 8.0),
                 Arguments.of("(2 + 3) * 2 - 1", 9.0),
                 Arguments.of("1 - 2 * 3 + 4", -1.0),
-                Arguments.of("1 + 2 * 3 - 4", 3.0)
+                Arguments.of("1 + 2 * 3 - 4", 3.0),
+
+                // Same expressions but without spacing
+                Arguments.of("1+2", 3.0),
+                Arguments.of("-1+-2", -3.0),
+                Arguments.of("1/2", 0.5),
+                Arguments.of("1/4", 0.25),
+                Arguments.of("1/4+1/4", 0.5),
+                Arguments.of("4/1*2", 8.0),
+                Arguments.of("4/0", Double.POSITIVE_INFINITY),
+                Arguments.of("-4/0", Double.NEGATIVE_INFINITY),
+                Arguments.of("2*3", 6.0),
+                Arguments.of("-2*3", -6.0),
+                Arguments.of("2^3", 8.0),
+                Arguments.of("(2+3)*2-1", 9.0),
+                Arguments.of("1-2*3+4", -1.0),
+                Arguments.of("1+2*3-4", 3.0),
+
+                // Expressions targeting the negation operator
+                Arguments.of("3-4", -1.0),
+                Arguments.of("3--4", 7.0),
+                Arguments.of("-(1+2)", -3.0)
         );
     }
 }


### PR DESCRIPTION
Hello @arothuis! I realize this project is a small demonstration of ANTLR4, but I was interested in expanding the calculator's function and became annoyed with the strict formatting of the input. For example, I wanted to enter "6-4" instead of "6 + -4". No spaces to worry about. This PR accomplishes that objective. The trade-off is a slight muddling of your clear demo code.

This can be considered a hack, but it didn't seem too egregious and the benefit is nice. Also, a discussion of the fix could be beneficial to new users of ANTLR. Let me know what you think.

There are a few more minor edits to address compilation warnings.